### PR TITLE
fix tee

### DIFF
--- a/labs/2-cgroups-namespaces/index.md
+++ b/labs/2-cgroups-namespaces/index.md
@@ -134,7 +134,7 @@ echo $$
 
 Add your shell to the cgroup
 ```bash
-echo 942 > sudo tee /sys/fs/cgroup/freezer/mycgroup/cgroup.procs
+echo 942 | sudo tee /sys/fs/cgroup/freezer/mycgroup/cgroup.procs
 ```
 
 Verify your shell is now in the cgroup


### PR DESCRIPTION
`|` keeps it piping, `>` expects a file output, so it was printing everything to a file called sudo